### PR TITLE
Add tqdm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ setup(name = 'cdcs',
       packages = find_packages(),
       install_requires = [
         'requests',
-        'pandas'
+        'pandas',
+        'tqdm',
       ],
       package_data={'': ['*']},
       zip_safe = False)


### PR DESCRIPTION
`tqdm` is a [run-time dependency](https://github.com/usnistgov/pycdcs/blob/master/cdcs/CDCS/_query.py#L5).