### PR TITLE
Add ipython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(name = 'cdcs',
       author_email = 'lucas.hale@nist.gov',
       packages = find_packages(),
       install_requires = [
+        'ipython',
         'requests',
         'pandas'
       ],


### PR DESCRIPTION
`ipython` is a [run-time requirement](https://github.com/usnistgov/pycdcs/blob/master/cdcs/CDCS/_record.py#L7).